### PR TITLE
fix(index): rename oxStatus to jansStatus

### DIFF
--- a/static/sql/mysql_index.json
+++ b/static/sql/mysql_index.json
@@ -189,7 +189,7 @@
   "jansCibaReq": {
     "fields": [],
     "custom": [
-      "`oxStatus`, `exp`"
+      "`jansStatus`, `exp`"
     ]
   },
   "jansStatEntry": {

--- a/static/sql/spanner_index.json
+++ b/static/sql/spanner_index.json
@@ -174,7 +174,7 @@
   "jansCibaReq": {
     "fields": [],
     "custom": [
-      "`oxStatus`, `exp`"
+      "`jansStatus`, `exp`"
     ]
   },
   "jansStatEntry": {


### PR DESCRIPTION
This changeset rename `oxStatus` (found in templates for MySQL and Spanner indexes) to `jansStatus`.